### PR TITLE
If the user clicks outside of the popup, hide it

### DIFF
--- a/moogle.js
+++ b/moogle.js
@@ -21,6 +21,12 @@
   function eventListener() {
     showPopupButton.addEventListener('click', showPopup);
     closePopupButton.addEventListener('click', hidePopup);
+
+    document.onclick = function(event) {
+      if (event.target === popup) {
+        hidePopup();
+      }
+    };
   }
 
   function initMoogle() {


### PR DESCRIPTION
A simple change but effective: allow the closing of the pop-up modal by simply clicking outside of it.