### PR TITLE
Automate pop-up modal display on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,10 +31,44 @@
       </p>
 
       <p>
+        There are a few ways to enable the pop-up modal:
+      </p>
+
+      <p>
+        The most basic method is to activate by clicking or tapping on the 'Kupo!' button below.
+      </p>
+
+      <p>
         <button id="kupo__open" class="moogle__button">
           Kupo!
         </button>
       </p>
+
+      <p>
+        The second method is to simply scroll the page. When you scroll over half way through the page, the pop-up modal will appear.
+      </p>
+
+      <p>
+        The code for this project is freely available on <a href="https://github.com/kerrance/moogle" target="_blank" class="moogle__link">GitHub</a>, so please feel free to make use of it if you would like to use something similar on your own website. All I ask is that you 'Star' the repository for future reference, or credit the repository in your README file.
+      </p>
+
+      <hr class="moogle__horizontal-rule" />
+
+      <h3 class="moogle__heading">
+        Credits
+      </h3>
+
+      <ul class="moogle__list">
+        <li class="moogle__list-item">
+          <a href="https://www.colourlovers.com/palette/1223237/Moogles" target="_blank" class="moogle__link">
+            Moogles" colourscheme by tallib
+          </a>
+        </li>
+
+        <li class="moogle__list-item">
+          Square Enix for creating Moogles as part of the Final Fantasy series.
+        </li>
+      </ul>
     </div>
   </article>
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     </div>
   </header>
 
-  <section class="moogle__content">
+  <article class="moogle__content">
     <div class="moogle__container">
       <p>
         Hello!
@@ -36,7 +36,7 @@
         </button>
       </p>
     </div>
-  </section>
+  </article>
 
   <footer class="moogle__footer">
     <div class="moogle__container">

--- a/index.html
+++ b/index.html
@@ -93,7 +93,15 @@
       <article class="kupo__content">
         <div class="kupo__container">
           <p>
-            Popup body content.
+            If you're reading this, then the pop-up has successfully displayed, kupo.
+          </p>
+
+          <p>
+            You could put any number of exciting things in this pop-up kupo, like a mailing list subscription form, or a free download kupo.
+          </p>
+
+          <p>
+            But, I think it would be best if you don't use it to put adverts on your website, that would be <strong>really</strong> annoying for your readers kupo.
           </p>
         </div>
       </article>

--- a/moogle.js
+++ b/moogle.js
@@ -9,6 +9,8 @@
   const popup = document.getElementById('kupo');
   const showPopupButton = document.getElementById('kupo__open');
   const closePopupButton = document.getElementById('kupo__close');
+  const rootElement = document.documentElement;
+  const scrollTotal = rootElement.scrollHeight - rootElement.clientHeight;
 
   function showPopup() {
     popup.classList.add('kupo__active');
@@ -18,11 +20,18 @@
     popup.classList.remove('kupo__active');
   }
 
+  function showPopupOnScroll() {
+    if ((rootElement.scrollTop / scrollTotal) > 0.6) {
+      showPopup();
+    }
+  }
+
   function eventListener() {
     showPopupButton.addEventListener('click', showPopup);
     closePopupButton.addEventListener('click', hidePopup);
+    document.addEventListener('scroll', showPopupOnScroll);
 
-    document.onclick = function(event) {
+    rootElement.onclick = function(event) {
       if (event.target === popup) {
         hidePopup();
       }

--- a/styles.css
+++ b/styles.css
@@ -104,15 +104,16 @@ p:last-of-type {
  */
 
 .kupo {
+  width: 100vw;
+  height: 100vh;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
   transition: all 0.5s ease;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   display: flex;
   align-items: center;
   background-color: rgba(51, 35, 98, 0.6);

--- a/styles.css
+++ b/styles.css
@@ -81,6 +81,7 @@ p:last-of-type {
 
 .moogle__link {
   color: #750a10;
+  font-weight: bold;
 }
 
 .moogle__button {

--- a/styles.css
+++ b/styles.css
@@ -33,6 +33,7 @@ html {
 body {
   max-width: 80vw;
   margin: 0 auto;
+  padding: 1rem 0;
   background-color: #d2cbc5;
   color: #332362;
 }
@@ -71,10 +72,12 @@ p:last-of-type {
 .moogle__header {
   border-top-left-radius: 1rem;
   border-top-right-radius: 1rem;
+  margin-top: 0;
 }
 
 .moogle__footer {
   border-bottom-right-radius: 1rem;
+  margin-bottom: 0;
 }
 
 .moogle__container {

--- a/styles.css
+++ b/styles.css
@@ -25,11 +25,6 @@ select {
   scroll-behavior: smooth;
 }
 
-html {
-  height: 100vh;
-  position: relative;
-}
-
 body {
   max-width: 80vw;
   margin: 0 auto;

--- a/styles.css
+++ b/styles.css
@@ -95,6 +95,16 @@ p:last-of-type {
   outline: #d2cbc5 auto 1px;
 }
 
+.moogle__horizontal-rule {
+  border: none;
+  border-top: #332362 solid 0.2rem;
+  margin: 1rem auto;
+}
+
+.moogle__list:last-of-type {
+  margin-bottom: 0;
+}
+
 /**
  * Kupo
  */
@@ -144,12 +154,21 @@ p:last-of-type {
   color: #750A10;
 }
 
+@media (max-width: 767px) {
+  .kupo__header,
+  .kupo__content,
+  .kupo__footer {
+    margin: 0.4rem auto;
+    padding: 0 0.4rem;
+  }
+}
+
 .kupo__header {
   margin-top: 0;
 }
 
 .kupo__content {
-  text-align: center;
+  margin: 0;
 }
 
 .kupo__footer {
@@ -159,6 +178,12 @@ p:last-of-type {
 
 .kupo__container {
   padding: 1rem 0;
+}
+
+@media (max-width: 767px) {
+  .kupo__container {
+    padding: 0.4rem 0;
+  }
 }
 
 .kupo__button {


### PR DESCRIPTION
This change creates a second method for displaying the pop-up modal: scrolling down the page. I've also added more content to the page and tightened up some of the design.

The implementation is a little fiddly if you're constantly refreshing and/or the page doesn't have a lot of content to fill the document height, so I think that it could be improved by only showing once. I will look at that in a follow-up PR.