### PR TITLE
Only show the pop-up modal once per pageload (unless explicitly requested)

### DIFF
--- a/moogle.js
+++ b/moogle.js
@@ -11,6 +11,7 @@
   const closePopupButton = document.getElementById('kupo__close');
   const rootElement = document.documentElement;
   const scrollTotal = rootElement.scrollHeight - rootElement.clientHeight;
+  let alreadyShown = false;
 
   function showPopup() {
     popup.classList.add('kupo__active');
@@ -18,11 +19,14 @@
 
   function hidePopup() {
     popup.classList.remove('kupo__active');
+    alreadyShown = true;
   }
 
   function showPopupOnScroll() {
-    if ((rootElement.scrollTop / scrollTotal) > 0.6) {
-      showPopup();
+    if (alreadyShown !== true) {
+      if ((rootElement.scrollTop / scrollTotal) > 0.6) {
+        showPopup();
+      }
     }
   }
 


### PR DESCRIPTION
This is a quick fix to improve the usability of the pop-up modal.

If the reader has already dismissed the modal by closing it or clicking off of it, they won't expect to see it again. This change ensures that the modal will only display once on page load by scrolling the page, once dismissed it will only appear again when explicitly requested (with the button).

In a follow up PR, I will set a cookie which will 'explicitly' confirm that the reader doesn't want or need to see the pop-up again which will carry over multiple page loads.