### PR TITLE
Set a cookie when dismissing the pop-up to prevent frustration

### DIFF
--- a/moogle.js
+++ b/moogle.js
@@ -1,8 +1,8 @@
 /**
  * Moogle.js
- * 
+ *
  * Version: 1.0.0
- * 
+ *
  * Website: https://kerrance.github.io/moogle/
  */
 ( function() {

--- a/moogle.js
+++ b/moogle.js
@@ -45,10 +45,29 @@
     }
   }
 
+  function getCookie(name) {
+    const allCookies = document.cookie.split(';');
+
+    for(let i = 0; i < allCookies.length; i++) {
+      const cookiePair = allCookies[i].split('=');
+
+      if(name === cookiePair[0].trim()) {
+        return decodeURIComponent(cookiePair[1]);
+      }
+    }
+
+    return null;
+  }
+
   function eventListener() {
     showPopupButton.addEventListener('click', showPopup);
     closePopupButton.addEventListener('click', explicitlyDismissPopup);
-    document.addEventListener('scroll', showPopupOnScroll);
+
+    const explicitlyDismissedPopup = getCookie('kupoExplicitlyDismissed');
+
+    if (explicitlyDismissedPopup !== '' && explicitlyDismissedPopup === true) {
+      document.addEventListener('scroll', showPopupOnScroll);
+    }
 
     rootElement.onclick = function(event) {
       if (event.target === popup) {

--- a/moogle.js
+++ b/moogle.js
@@ -22,6 +22,11 @@
     alreadyShown = true;
   }
 
+  function explicitlyDismissPopup() {
+    setCookie('kupoExplicitlyDismissed', true, 28);
+    hidePopup();
+  }
+
   function showPopupOnScroll() {
     if (alreadyShown !== true) {
       if ((rootElement.scrollTop / scrollTotal) > 0.6) {
@@ -30,9 +35,19 @@
     }
   }
 
+  function setCookie(name, value, daysToLive) {
+    if(typeof daysToLive === 'number') {
+      let date = new Date();
+      date.setTime(date.getTime() + (daysToLive*24*60*60*1000));
+      let expires = '; expires=' + date.toUTCString();
+
+      document.cookie = name + '=' + encodeURIComponent(value) + expires + '; path=/; secure';
+    }
+  }
+
   function eventListener() {
     showPopupButton.addEventListener('click', showPopup);
-    closePopupButton.addEventListener('click', hidePopup);
+    closePopupButton.addEventListener('click', explicitlyDismissPopup);
     document.addEventListener('scroll', showPopupOnScroll);
 
     rootElement.onclick = function(event) {


### PR DESCRIPTION
This ensures that, when the pop-up modal has been explicitly closed (for example: when using the 'Close' button), then it won't appear again (unless explicitly requested with a button press).

This is different from an implicit closure, such as when clicking off the pop-up modal without pressing the button, where the pop-up will appear again without explicitly being requested after page refresh.